### PR TITLE
Refactor Event User Route

### DIFF
--- a/server/api/users.js
+++ b/server/api/users.js
@@ -20,7 +20,6 @@ router.get('/friends', async (req, res, next) => {
   try {
     const user = await User.findById(req.user.id)
     const friends = await user.getFriends()
-    console.log("friends in route", friends)
     res.json(friends)
   } catch (err) {
     next(err)

--- a/server/db/models/event-user.js
+++ b/server/db/models/event-user.js
@@ -8,4 +8,9 @@ const EventUser = db.define('event_user', {
   }
 })
 
+EventUser.prototype.setAdmin = function(){
+  console.log(this.userId, this.eventId)
+  this.isAdmin = !this.isAdmin
+}
+
 module.exports = EventUser

--- a/server/db/models/event.js
+++ b/server/db/models/event.js
@@ -12,10 +12,6 @@ const Event = db.define('event', {
   description: {
     type: Sequelize.TEXT,
   },
-  guests: {
-    type: Sequelize.ARRAY(Sequelize.STRING),
-    allowNull: false
-  },
   isPrivate: {
     type: Sequelize.BOOLEAN,
     defaultValue: false


### PR DESCRIPTION
What did you change?
Route when creating event now pushes users as guests to event_user table, not event table

What did it fix or what is now possible because of your change?
can access guests of an event correctly

Is there anything that needs to happen as a result of this change?
no

Are there any questions you had about the implementation or other possibilities you'd like the reviewers to consider?
no

=(^_^)=
