### PR TITLE
Markers Stay in Place

### DIFF
--- a/client/components/Events/Map.js
+++ b/client/components/Events/Map.js
@@ -2,18 +2,13 @@ import React, {Component} from 'react'
 import GoogleMapReact from 'google-map-react'
 import GOOGLE_API_KEY from '../../../secrets'
 import Loader from '../Utils/Loader'
+import {Icon} from 'semantic-ui-react'
+
+const CustomMarker = () => <Icon name="flag checkered" size="big"/>
 
 class Map extends Component {
-  //  static defaultProps = {
-  //   center: {
-  //     lat: this.props.latitude,
-  //     lng: this.props.longitude
-  //   },
-  //   zoom: 11
-  // };
   render() {
     const {latitude, longitude} = this.props
-    console.log(latitude, longitude)
 
     return (
       <div style={{height: '50vh', width: '100%'}}>
@@ -24,9 +19,14 @@ class Map extends Component {
               lat: latitude,
               lng: longitude
             }}
-            center={[latitude, longitude]}
-            defaultZoom={14}
-          />
+            center={{
+              lat: latitude,
+              lng: longitude
+            }}
+            defaultZoom={15}
+          >
+            <CustomMarker lat={latitude} lng={longitude} />
+          </GoogleMapReact>
         ) : (
           <Loader />
         )}


### PR DESCRIPTION
fix: marker loads at correct lat/long
I discovered that there is a bug that got introduced to google-map-react in 2016 when React was updated where you specifically can't make DOM elements the children of a map. That's why they introduced the work around of creating your own non-element element with the function outside of the map constructor (AnyReactElement). It would have been sooooo much clearer if they had called it 'CustomMarker' instead. I should make a suggestion. Anyway, it's working now! I also fixed the line where we were defining the center as an array. Reading through the google-map-react code and the google maps docs, it seemed like defining it as an object made more sense.

=(^\_^)=
