### PR TITLE
Google oauth now redirecting properly

### DIFF
--- a/client/components/Auth/auth-form.js
+++ b/client/components/Auth/auth-form.js
@@ -75,7 +75,7 @@ const AuthForm = props => {
             <Button fluid color="vk" size="large" style={styles.mBottom}>
               {displayName}
             </Button>
-            <Button fluid as={Link} to="/auth/google" color="google plus">
+            <Button fluid as="a" href="/auth/google" color="google plus">
               <Icon name="google" />
               {displayName} with Google
             </Button>


### PR DESCRIPTION
**What did you change?**
oAuth button was link - now it's just an href

**What did it fix or what is now possible because of your change?**
Google oAuth is now redirecting properly

=(^\_^)=
